### PR TITLE
Open File Assertion Fixed

### DIFF
--- a/lib/src/fl_downloader_src.dart
+++ b/lib/src/fl_downloader_src.dart
@@ -127,7 +127,7 @@ class FlDownloader {
   /// on Android. On iOS you can open using only the [filePath]
   static Future<void> openFile({int? downloadId, String? filePath}) async {
     assert(
-      (downloadId != null) ^ (filePath != null),
+      (downloadId != null) == (filePath != null),
       'You can open a file by downloadId or by filePath, not both',
     );
     assert(


### PR DESCRIPTION
The method openFile had an assertion (downloadId != null) ^ (filePath != null) for checking that only one of them is carrying a value. But the xor gate in between was working opposite to what we wanted so I replaced ^ with == .