### PR TITLE
[android] MIME type is empty if the file name contains spaces

### DIFF
--- a/android/src/main/kotlin/dev/inceptusp/fl_downloader/FlDownloaderPlugin.kt
+++ b/android/src/main/kotlin/dev/inceptusp/fl_downloader/FlDownloaderPlugin.kt
@@ -173,7 +173,7 @@ class FlDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAware, Requ
     val authority = context.applicationContext.packageName + ".flDownloader.provider"
     val fileUri = Uri.parse(downloadedTo)
     val mimeMap = MimeTypeMap.getSingleton()
-    val ext = MimeTypeMap.getFileExtensionFromUrl(fileUri.path)
+    val ext = MimeTypeMap.getFileExtensionFromUrl(fileUri.encodedPath)
     var type = mimeMap.getMimeTypeFromExtension(ext)
     if (type == null) type = "*/*"
     val uri = FileProvider.getUriForFile(context, authority, File(fileUri.path!!))


### PR DESCRIPTION
`MimeTypeMap.getFileExtensionFromUrl` returns an empty string if the parameter given contains space characters (See https://issuetracker.google.com/issues/36911541).

This PR changes the parameter sent to `MimeTypeMap.getFileExtensionFromUrl` (`fileUri.encodedPath` instead of `fileUri.path`) in order to eliminate this problem.